### PR TITLE
Disregard whitespace and ordering differences in alert filter

### DIFF
--- a/logzio/common.go
+++ b/logzio/common.go
@@ -1,6 +1,8 @@
 package logzio
 
 import (
+	"encoding/json"
+	"reflect"
 	"strings"
 	"unicode"
 )
@@ -30,4 +32,24 @@ func stripAllWhitespace(inputString string) string {
 		}
 	}
 	return b.String()
+}
+
+func jsonEqual(old, new string) bool {
+	if old == new {
+		return true
+	}
+
+	var expected, actual interface{}
+	oldString := stripAllWhitespace(old)
+	newString := stripAllWhitespace(new)
+
+	if err := json.Unmarshal([]byte(oldString), &expected); err != nil {
+		return oldString == newString
+	}
+
+	if err := json.Unmarshal([]byte(newString), &actual); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(expected, actual)
 }

--- a/logzio/common.go
+++ b/logzio/common.go
@@ -1,6 +1,9 @@
 package logzio
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 const (
 	BASE_10            int    = 10
@@ -16,4 +19,15 @@ func findStringInArray(v string, values []string) bool {
 		}
 	}
 	return false
+}
+
+func stripAllWhitespace(inputString string) string {
+	var b strings.Builder
+	b.Grow(len(inputString))
+	for _, ch := range inputString {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
 }

--- a/logzio/common_test.go
+++ b/logzio/common_test.go
@@ -55,3 +55,45 @@ lines`
 
 	assert.EqualValues(t, expected, stripAllWhitespace(input))
 }
+
+func TestDiffJsonReturnsTrueWhenStructurallyTheSame(t *testing.T) {
+	old := "{\"a\":{\"c\": []}, \"b\": true}"
+	new := "{\"b\": true, \"a\":{\"c\": []}}"
+
+	assert.True(t, jsonEqual(old, new))
+}
+
+func TestDiffJsonReturnsNotEqualWhenJsonIsDifferent(t *testing.T) {
+	old := "{\"a\":{\"c\": []}, \"b\": true}"
+	new := "{\"b\": true, \"a\":{\"d\": []}}"
+
+	assert.False(t, jsonEqual(old, new))
+}
+
+func TestDiffJsonReturnsTrueWhenStringsTheSameAndJson(t *testing.T) {
+	old := "{}"
+	new := "{}"
+
+	assert.True(t, jsonEqual(old, new))
+}
+
+func TestDiffJsonReturnsTrueWhenStringsTheSameButNotJson(t *testing.T) {
+	old := "{a"
+	new := "{a"
+
+	assert.True(t, jsonEqual(old, new))
+}
+
+func TestDiffJsonReturnsTrueWithExcessWhiteSpace(t *testing.T) {
+	old := "{\"a\":{\"c\": []}, \"b\": true}"
+	new := "{\"b\": true, \"a\":{\"c\": []}}"
+
+	assert.True(t, jsonEqual(old, new))
+}
+
+func TestDiffJsonReturnsTrueWhenAreTheSame(t *testing.T) {
+	old := "{\"a\":{\"c\": []}, \"b\": true}"
+	new := "{\"a\":{\"c\": []}, \"b\": true}"
+
+	assert.True(t, jsonEqual(old, new))
+}

--- a/logzio/common_test.go
+++ b/logzio/common_test.go
@@ -1,0 +1,57 @@
+package logzio
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStripWhitespaceReturnsDesiredResult(t *testing.T) {
+	input := "test string with	tabs"
+	expected := "teststringwithtabs"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsEmpty(t *testing.T) {
+	input := ""
+	expected := ""
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustSpaces(t *testing.T) {
+	input := "        "
+	expected := ""
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustTabs(t *testing.T) {
+	input := "				"
+	expected := ""
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringIsJustCharacters(t *testing.T) {
+	input := "abcdefghijklmnoplqrstuvwxyz"
+	expected := "abcdefghijklmnoplqrstuvwxyz"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringHasWhiteSpaceAtFrontAndBack(t *testing.T) {
+	input := "     text with whitespace at front and back    	"
+	expected := "textwithwhitespaceatfrontandback"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}
+
+func TestStripWhitespaceReturnsDesiredResultWhenInputStringHasCarraigeReturn(t *testing.T) {
+	input := `this string
+	spans multiple
+lines`
+	expected := "thisstringspansmultiplelines"
+
+	assert.EqualValues(t, expected, stripAllWhitespace(input))
+}

--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jonboydell/logzio_client/alerts"
@@ -67,6 +68,9 @@ func resourceAlert() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "{\"bool\":{\"must\":[], \"must_not\":[]}}",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(stripAllWhitespace(old), stripAllWhitespace(old))
+				},
 			},
 			alert_group_by_aggregation_fields: {
 				Type:     schema.TypeList,

--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
-	"strconv"
-	"strings"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jonboydell/logzio_client/alerts"
+	"log"
+	"strconv"
 )
 
 const (
@@ -69,7 +67,7 @@ func resourceAlert() *schema.Resource {
 				Optional: true,
 				Default:  "{\"bool\":{\"must\":[], \"must_not\":[]}}",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.EqualFold(stripAllWhitespace(old), stripAllWhitespace(old))
+					return jsonEqual(old, new)
 				},
 			},
 			alert_group_by_aggregation_fields: {

--- a/logzio/resource_alert_test.go
+++ b/logzio/resource_alert_test.go
@@ -52,6 +52,29 @@ func TestAccLogzioAlert_UpdateAlert(t *testing.T) {
 	})
 }
 
+func TestAccLogzioAlert_UpdateFilterWhiteSpace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: resourceCreateAlert("test_update_filter_alert"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"logzio_alert.test_update_alert", "title", "hello"),
+				),
+			},
+			resource.TestStep{
+				Config: resourceUpdateFilterAlert("test_update_filter_alert"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"logzio_alert.test_update_alert", "filter", "{\"bool\":{\"must\":[],\"filter\":[],\"should\":[],\"must_not\":[]}}"),
+				),
+			},
+		},
+	})
+}
+
 func resourceCreateAlert(name string) string {
 	content, err := ioutil.ReadFile("testdata/fixtures/create_alert.tf")
 	if err != nil {
@@ -62,6 +85,14 @@ func resourceCreateAlert(name string) string {
 
 func resourceUpdateAlert(name string) string {
 	content, err := ioutil.ReadFile("testdata/fixtures/update_alert.tf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return fmt.Sprintf(fmt.Sprintf("%s", content), name)
+}
+
+func resourceUpdateFilterAlert(name string) string {
+	content, err := ioutil.ReadFile("testdata/fixtures/update_filter_alert.tf")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/logzio/resource_alert_test.go
+++ b/logzio/resource_alert_test.go
@@ -52,7 +52,7 @@ func TestAccLogzioAlert_UpdateAlert(t *testing.T) {
 	})
 }
 
-func TestAccLogzioAlert_UpdateFilterWhiteSpace(t *testing.T) {
+func TestAccLogzioAlert_UpdateFilterWithOrderingDifference(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -61,14 +61,14 @@ func TestAccLogzioAlert_UpdateFilterWhiteSpace(t *testing.T) {
 				Config: resourceCreateAlert("test_update_filter_alert"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"logzio_alert.test_update_alert", "title", "hello"),
+						"logzio_alert.test_update_filter_alert", "filter", "{\"bool\":{\"must\":[],\"should\":[],\"filter\":[],\"must_not\":[]}}"),
 				),
 			},
 			resource.TestStep{
 				Config: resourceUpdateFilterAlert("test_update_filter_alert"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"logzio_alert.test_update_alert", "filter", "{\"bool\":{\"must\":[],\"filter\":[],\"should\":[],\"must_not\":[]}}"),
+						"logzio_alert.test_update_filter_alert", "filter", "{\"bool\":{\"must\":[],\"should\":[],\"filter\":[],\"must_not\":[]}}"),
 				),
 			},
 		},

--- a/logzio/testdata/fixtures/create_alert.tf
+++ b/logzio/testdata/fixtures/create_alert.tf
@@ -2,7 +2,7 @@ resource "logzio_alert" "%s" {
   title = "hello"
   query_string = "loglevel:ERROR"
   operation = "GREATER_THAN"
-  filter = "{\"bool\":{\"must\":[],\"filter\":[],\"should\":[],\"must_not\":[]}}"
+  filter = "{\"bool\":{\"must\":[],\"should\":[],\"filter\":[],\"must_not\":[]}}"
   notification_emails = ["testx@test.com"]
   search_timeframe_minutes = 5
   value_aggregation_type = "NONE"

--- a/logzio/testdata/fixtures/update_alert.tf
+++ b/logzio/testdata/fixtures/update_alert.tf
@@ -2,6 +2,7 @@ resource "logzio_alert" "%s" {
   title = "updated_alert"
   query_string = "loglevel:ERROR"
   operation = "GREATER_THAN"
+  filter = "{\"bool\":{\"must\":[],\"filter\":[],\"should\":[],\"must_not\":[]}}"
   notification_emails = ["testx@test.com"]
   search_timeframe_minutes = 5
   value_aggregation_type = "NONE"

--- a/logzio/testdata/fixtures/update_filter_alert.tf
+++ b/logzio/testdata/fixtures/update_filter_alert.tf
@@ -1,8 +1,8 @@
 resource "logzio_alert" "%s" {
-  title = "hello"
+  title = "updated_alert"
   query_string = "loglevel:ERROR"
   operation = "GREATER_THAN"
-  filter = "{\"bool\":{\"must\":[],\"filter\":[],\"should\":[],\"must_not\":[]}}"
+  filter = "{\"bool\":{\"must\":   [],  \"filter\":[],   \"should\":[], \"must_not\":[]}}"
   notification_emails = ["testx@test.com"]
   search_timeframe_minutes = 5
   value_aggregation_type = "NONE"

--- a/logzio/testdata/fixtures/update_filter_alert.tf
+++ b/logzio/testdata/fixtures/update_filter_alert.tf
@@ -1,5 +1,5 @@
 resource "logzio_alert" "%s" {
-  title = "updated_alert"
+  title = "hello"
   query_string = "loglevel:ERROR"
   operation = "GREATER_THAN"
   filter = "{\"bool\":{\"must\":   [],  \"filter\":[],   \"should\":[], \"must_not\":[]}}"


### PR DESCRIPTION
Prevent the recreation or update of a resource because of whitespace in
the filter attribute of the alert.

### Proof of test
==========

API server listening at: 127.0.0.1:53931
=== RUN   TestAccLogzioAlert_UpdateFilterWithOrderingDifference
--- PASS: TestAccLogzioAlert_UpdateFilterWithOrderingDifference (30.46s)
PASS

